### PR TITLE
Add dropout auto tune UI sync

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # 변경 이력
 
+## v1.20
+- Auto-Tune이 dropout_ratio 값을 포함해 제안하며 UI 입력폼에 바로 적용되도록 개선.
+
 ## v1.19
 - DataLoader가 배치 크기, num_workers, pin_memory 설정을
   Auto-Tune 결과와 사용자 설정 그대로 반영하도록 수정.

--- a/src/tuning/auto.py
+++ b/src/tuning/auto.py
@@ -61,6 +61,7 @@ class AutoTuner:
                 "num_decoder_layers": num_layers,
                 "num_epochs": 30 if self.dataset_size > 300 else 15,
                 "learning_rate": 5e-4 if self.dataset_size > 300 else 1e-3,
+                "dropout_ratio": 0.1 if self.dataset_size > 500 else 0.2,
                 "use_mixed_precision": bool(
                     torch.cuda.is_available() and self.vram_gb >= 6
                 ),

--- a/ui.html
+++ b/ui.html
@@ -1173,6 +1173,11 @@
               setVal('decLayersInput',  cfg.num_decoder_layers);
               setVal('epochsInput',     cfg.num_epochs);
               setVal('lrInput',         cfg.learning_rate);
+              if (cfg.dropout_ratio !== undefined) {
+                setVal('dropoutInput', cfg.dropout_ratio);
+                const dv = document.getElementById('dropoutValue');
+                if (dv) dv.textContent = parseFloat(cfg.dropout_ratio).toFixed(2);
+              }
               setVal('mpCheckbox',      cfg.use_mixed_precision);
               updateTrainingButtons();
             }


### PR DESCRIPTION
## Summary
- update AutoTuner.suggest to include `dropout_ratio`
- apply auto tune dropout value to UI inputs
- document improvement

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy' and 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685b53156f88832a9e828d3ccf3b139e