### PR TITLE
Improve Auto-Tune dataset scan

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # 변경 이력
+## v1.29
+- Auto-Tune 스캔 로직이 `pretrain`, `finetune`, `additional_finetune` 폴더만 탐색하도록 조정.
+- JSONL 처리 시 `instruction` 필드가 없는 라인은 샘플로 인정하지 않고 토큰 계산에서 제외.
+- `clean_subtitles.py`와 문서의 경로를 `datas/pretrain/`으로 변경.
 ## v1.28
 - Auto-Tuner가 모든 데이터셋 폴더를 순회해 샘플 수와 토큰 수를 계산하도록 수정.
 - Flash Attention 경고 억제 코드를 transformer.py 최상단으로 이동.
@@ -78,7 +82,7 @@
 - 학습 루프가 에폭별 손실과 소요 시간을 로그로 출력하도록 개선.
 
 ## v1.7
-- 자막 파일을 자동 정제하여 `datas/01_pretrain/`에 저장하는 로직 추가.
+- 자막 파일을 자동 정제하여 `datas/pretrain/`에 저장하는 로직 추가.
 - pretrain 학습 시작 시 정제기가 실행되도록 ChatbotService 수정.
 - 정제기 사용법 문서 `docs/subtitle_cleaner.md` 작성.
 

--- a/clean_subtitles.py
+++ b/clean_subtitles.py
@@ -23,7 +23,7 @@ def _clean_file(src: Path, dst: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Subtitle cleaner")
     parser.add_argument("src", type=Path, nargs="?", default=Path("."))
-    parser.add_argument("dst", type=Path, nargs="?", default=Path("datas/01_pretrain"))
+    parser.add_argument("dst", type=Path, nargs="?", default=Path("datas/pretrain"))
     args = parser.parse_args()
 
     if args.src.is_file():

--- a/docs/subtitle_cleaner.md
+++ b/docs/subtitle_cleaner.md
@@ -6,6 +6,6 @@
 ## 사용법
 1. 자막 파일을 루트 디렉터리에 배치한다.
 2. `ChatbotService.start_training("pretrain")` 호출 시 정제기가 실행된다.
-3. 추출된 문장은 `datas/01_pretrain/` 폴더의 동일한 이름의 `.txt` 파일로 저장된다.
+3. 추출된 문장은 `datas/pretrain/` 폴더의 동일한 이름의 `.txt` 파일로 저장된다.
 
 모든 태그와 타임코드는 제거되며 한 줄에 하나의 대사만 남는다.

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -35,7 +35,7 @@ class ChatbotService:
 
     def __init__(self) -> None:
         self.data_dir = Path("datas")
-        self.pretrain_dir = self.data_dir / "01_pretrain"
+        self.pretrain_dir = self.data_dir / "pretrain"
         self.finetune_dir = self.data_dir / "finetune"
         self.additional_dir = self.data_dir / "additional_finetune"
         self.model_dir = Path("models")


### PR DESCRIPTION
## Summary
- refine dataset info scan to ignore `01_` folders and JSON files
- skip jsonl lines without `instruction`
- update pretrain data path and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c029bd944832a8a5ff2b2bc89304d