### PR TITLE
Add runtime debug outputs and adjust warning filter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 # 변경 이력
+## v1.30
+- Flash Attention 경고 억제 시점을 학습 루프 시작 직전으로 이동.
+- GPU 메모리 사용량과 데이터 평균 길이를 디버그 출력하도록 보강.
 ## v1.29
 - Auto-Tune 스캔 로직이 `pretrain`, `finetune`, `additional_finetune` 폴더만 탐색하도록 조정.
 - JSONL 처리 시 `instruction` 필드가 없는 라인은 샘플로 인정하지 않고 토큰 계산에서 제외.

--- a/run.py
+++ b/run.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import platform
 import warnings
 
-if platform.system() == "Windows":
-    warnings.filterwarnings("ignore", message="Torch was not compiled with flash attention")
-
 try:  # pragma: no cover - optional dependency
     import webview  # type: ignore
 except Exception:  # pragma: no cover

--- a/src/model/transformer.py
+++ b/src/model/transformer.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 import warnings
 import platform
 
-if platform.system() == "Windows":
-    warnings.filterwarnings("ignore", message="Torch was not compiled with flash attention")
-
 import math
 import logging
 from pathlib import Path


### PR DESCRIPTION
## Summary
- move flash attention warning suppression near training loop
- add dataset and GPU memory debug outputs
- update changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c06b26780832a8d8ab49b2e24096f