### PR TITLE
Add pretrain mode to run.py

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 # 변경 이력
+## v1.42
+- run.py에서 `pretrain` 모드를 CLI 옵션으로 추가해 GUI와 동일하게 사용 가능하게 수정.
+- 선택한 모드에 따라 `start_training("pretrain")`를 호출하도록 분기 처리.
 ## v1.41
 - `src/training/simple.py`에서 로거 변수를 함수 안에서 재정의해 `UnboundLocalError`가 발생하던 문제를 수정.
 - 모듈 상단에 전역 `logger`를 선언해 모든 함수에서 동일한 로거를 사용하도록 통일.

--- a/run.py
+++ b/run.py
@@ -49,7 +49,11 @@ def _ensure_cuda_torch() -> None:
 def main() -> None:
     """Entry point for training or serving."""
     parser = argparse.ArgumentParser(description="Chatbot runner")
-    parser.add_argument("--mode", choices=["train", "serve"], default="serve")
+    parser.add_argument(
+        "--mode",
+        choices=["train", "pretrain", "serve"],
+        default="serve",
+    )
     parser.add_argument("--config", dest="config_path")
     parser.add_argument("--data-dir")
     parser.add_argument("--model-path")
@@ -65,7 +69,13 @@ def main() -> None:
     setup_logger()
     _ensure_cuda_torch()
 
-    if args.mode == "train":
+    if args.mode == "pretrain":
+        from src.service.service import ChatbotService
+
+        svc = ChatbotService()
+        svc.start_training("pretrain")
+        return
+    elif args.mode == "train":
         from src.service.service import ChatbotService
 
         svc = ChatbotService()


### PR DESCRIPTION
## Summary
- support `pretrain` mode when launching `run.py`
- document new CLI option in Changelog

## Testing
- `python -m py_compile run.py`
- `python run.py --mode pretrain --epochs 1` *(fails: unrecognized arguments)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cbbdda7c0832ab425b1ed6e618848