### PR TITLE
Apply speed optimization settings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,10 @@
 # 변경 이력
+## v1.46
+- `cudnn.benchmark`를 전역에서 활성화해 반복 커널을 고정.
+- DataLoader 기본 `num_workers`를 4로 조정하고 `persistent_workers`를 사용.
+- 검증 로더는 `drop_last=False`로 유지하도록 수정.
+- epoch 비율 DEBUG 로그를 제거해 I/O를 최소화.
+- `config/default.yaml` 파일을 추가해 기본값을 명시.
 ## v1.45
 - AMP 사용이 안정화되어 기본 설정에서 True로 전환.
 - 기본 batch_size를 48로 확대하고 DataLoader가 마지막 미만 배치를 버리도록 수정.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,2 @@
+batch_size: 48
+use_mixed_precision: True

--- a/tests/test_dataloader_config.py
+++ b/tests/test_dataloader_config.py
@@ -13,7 +13,7 @@ def test_dataloader_uses_cfg(monkeypatch):
     captured = {}
     orig_loader = simple.DataLoader
 
-    def spy_loader(dataset, batch_size, shuffle, collate_fn, num_workers, pin_memory):
+    def spy_loader(dataset, batch_size, shuffle, collate_fn, num_workers, pin_memory, **kwargs):
         captured.update({'batch_size': batch_size, 'num_workers': num_workers, 'pin_memory': pin_memory})
         return orig_loader(dataset, batch_size=1, shuffle=shuffle, collate_fn=collate_fn, num_workers=0, pin_memory=False)
 


### PR DESCRIPTION
## Summary
- activate cudnn benchmark globally
- add config/default.yaml for default AMP & batch size
- adjust DataLoader defaults and persistent workers
- avoid debug I/O in training
- update dataloader config test

## Testing
- `python -m py_compile src/training/simple.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685ccb13137c832a9a5d9730548facb2