### PR TITLE
I've fixed an issue where your training script would fail to start if…

### DIFF
--- a/src/training/simple.py
+++ b/src/training/simple.py
@@ -99,9 +99,8 @@ def train(
     start_epoch = 0
     global_step = 0
     best_val_loss = float("inf")
-    if resume:
-        if not ckpt_path.exists():
-            raise FileNotFoundError(f"Checkpoint not found at {ckpt_path}")
+    if resume and ckpt_path.exists():
+        logger.info("Resume training from checkpoint: %s", ckpt_path)
         ckpt = torch.load(ckpt_path, map_location="cpu")
         cfg_ckpt = ckpt.get("cfg", cfg)
         model = _init_model(tokenizer, cfg_ckpt)
@@ -111,8 +110,13 @@ def train(
         best_val_loss = float(ckpt.get("best_metric", float("inf")))
         mode = "RESUME"
     else:
+        if resume:
+            logger.warning(
+                "Resume is true but checkpoint not found at %s. Starting fresh.",
+                ckpt_path,
+            )
         if model is None:
-            logger.info("Initializing a new model.")
+            logger.info("Initializing a new model for cold start.")
             model = _init_model(tokenizer, cfg)
         mode = "COLD_START"
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
… a checkpoint was missing.

Previously, the script would raise a `FileNotFoundError` if the `resume` option was enabled in the configuration but the corresponding checkpoint file (`models/training_state.pth`) was not found. This prevented you from starting a new training run after deleting old model files.

I have modified the resume logic in `src/training/simple.py`. The code now checks for the checkpoint's existence before attempting to load it. If the file is missing while `resume` is enabled, it will log a warning and gracefully fall back to a 'cold start' by creating a new model from scratch. This makes your training process more robust and resilient to missing files.