### PR TITLE
[수정] train_spm.py 임시 파일 경로 오류 해결

### DIFF
--- a/train_spm.py
+++ b/train_spm.py
@@ -27,20 +27,18 @@ try:
     if not input_files:
         raise FileNotFoundError(f"No .txt files found in directory: {input_dir}")
 
-    # Create a temporary file to hold all training data, ensuring UTF-8 encoding.
-    with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8', suffix='.txt') as tf:
+    # Create a temporary file in the current directory to avoid path encoding issues.
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8', suffix='.txt', dir='.') as tf:
         temp_input_file = tf.name
         print(f"Creating temporary UTF-8 input file at: {temp_input_file}")
         total_size = 0
         for filename in input_files:
             content = None
             try:
-                # Try reading as UTF-8 first (most common)
                 with open(filename, 'r', encoding='utf-8') as f:
                     content = f.read()
             except UnicodeDecodeError:
                 try:
-                    # If UTF-8 fails, try CP949 (common legacy Korean encoding on Windows)
                     print(f"Info: Could not read {filename} as UTF-8, trying 'cp949'...")
                     with open(filename, 'r', encoding='cp949') as f:
                         content = f.read()


### PR DESCRIPTION
`train_spm.py` 스크립트가 사용자 폴더 경로에 한글 등 Non-ASCII 문자가 포함될 경우 `Illegal byte sequence` 오류를 발생시키는 문제를 해결했습니다.

임시 파일을 시스템 기본 임시 폴더가 아닌, 프로젝트 최상위 디렉토리(ASCII 경로)에 생성하도록 `tempfile.NamedTemporaryFile(dir='.')` 옵션을 추가하여, SentencePiece 라이브러리가 파일 경로를 처리할 때 발생하던 인코딩 충돌을 원천적으로 방지합니다.