### PR TITLE
[버그수정] 학습 프로세스 TypeError 해결 (재제출)

### DIFF
--- a/src/training/simple.py
+++ b/src/training/simple.py
@@ -116,10 +116,11 @@ def _train_epoch(
     tokenizer: SentencePieceTokenizer,
     device: str,
     amp_enabled: bool,
-) -> float:
+) -> Tuple[float, float]:
     model.train()
     total_loss = 0.0
     step_count = 0
+    start_time = time.perf_counter()
     for i, (src, tgt) in enumerate(loader):
         src, tgt = src.to(device, non_blocking=True), tgt.to(device, non_blocking=True)
         if tgt.size(1) < 2:
@@ -137,7 +138,10 @@ def _train_epoch(
 
         total_loss += loss.item()
         step_count += 1
-    return total_loss / max(step_count, 1)
+
+    duration = time.perf_counter() - start_time
+    avg_loss = total_loss / max(step_count, 1)
+    return avg_loss, duration
 
 
 def train(


### PR DESCRIPTION
이전 커밋에서 누락되었던 `src/training/simple.py`의 `TypeError` 수정 사항을 다시 적용하여 제출합니다.

- `_train_epoch` 함수가 `loss`와 `duration` 두 값을 튜플로 올바르게 반환하도록 수정했습니다.