### PR TITLE
[버그수정] NameError: collate is not defined 해결

### DIFF
--- a/src/training/simple.py
+++ b/src/training/simple.py
@@ -26,7 +26,7 @@ import torch.nn.functional as F
 from ..data.loader import InstructionSample
 from ..model.transformer import Seq2SeqTransformer, save_transformer, load_transformer
 from ..utils.tokenizer import SentencePieceTokenizer
-from .helpers import PairDataset, timed_collate, log_dataset_stats
+from .helpers import PairDataset, collate, timed_collate, log_dataset_stats
 from .checkpoint import save_checkpoint, load_checkpoint
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
`src/training/simple.py` 파일에서 `collate` 함수를 import하지 않아 발생하던 `NameError`를 수정했습니다.

`_create_loader` 함수에서 `timed_collate` 대신 `collate`를 사용하도록 변경하면서, 해당 함수를 import 구문에 추가하는 것을 누락한 실수를 바로잡았습니다.