### PR TITLE
fix: improve cpu test compatibility

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # 변경 이력
+## v1.56
+- `training.simple`: `zero_grad(set_to_none=True)` 호출을 예외 처리 래핑하고, 패딩만 있는 배치·더미 옵티마이저를 안전하게 처리하도록 보강했습니다.
+- `service.infer`: 트랜스포머 모델에만 토크나이저를 필수로 요구하도록 검증 조건을 보강했습니다.
+- `service.auto_tune`: `get_dataset_info` 호출 시 추가 데이터 디렉터리를 인자로 전달하도록 수정했습니다.
 ## v1.55
 - README와 AGENTS 문서 상단에 GPU 전제, CPU 모드 사용 조건, 변경 사유 기록 의무를 명시했습니다.
 ## v1.54

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -184,7 +184,7 @@ class ChatbotService:
     def infer(self, text: str) -> Dict[str, Any]:
         if not self.model:
             return {"success": False, "msg": "no_model", "data": None}
-        if not self.tokenizer:
+        if isinstance(self.model, Seq2SeqTransformer) and not self.tokenizer:
             return {"success": False, "msg": "no_tokenizer", "data": None}
         if not text.strip():
             return {"success": False, "msg": "empty_input", "data": None}
@@ -231,7 +231,7 @@ class ChatbotService:
     def auto_tune(self) -> Dict[str, Any]:
         """Apply AutoTuner suggestions to config."""
         size, tokens, txt_lines, json_lines, skipped = get_dataset_info(
-            self.pretrain_dir, self.finetune_dir
+            self.pretrain_dir, self.finetune_dir, self.data_dir / "additional"
         )
         print(f"[DEBUG] Found pretrain txt files: {txt_lines} lines")
         print(f"[DEBUG] Found finetune jsonl files: {json_lines} lines")


### PR DESCRIPTION
## Summary
- wrap zero_grad calls for dummy optimizers and skip pad-only batches in `_train_epoch`
- require tokenizer only for transformer models and pass additional dir to `auto_tune`
- document v1.56 changes

## Testing
- `python -m compileall -q .`
- `ALLOW_CPU_TRAINING=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899f5f003cc832a909e187b93e6ad5c