### PR TITLE
v1.57: guard sdp_kernel and cudnn with env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Codex는 아래 지침을 무조건 준수하여 작업해야 합니다.
 datas/
     pretrain/              # 사전학습용 txt
     finetune/              # 1차 파인튜닝용 jsonl
-    additional_finetune/   # 추가 파인튜닝용 jsonl
+    additional_finetune/   # 이어학습용 jsonl
 ```
 
 각 폴더에는 `sample_pretrain.txt`, `sample_finetune.jsonl`, `sample_additional_finetune.jsonl` 예시 파일을 포함한다.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # 변경 이력
+## v1.57
+- `training.simple`에 sdp_kernel·cudnn 환경 변수 가드를 추가했습니다. Codex 내부 테스트는 GPU 미지원으로 `ALLOW_CPU_TRAINING=1` 설정 후 `tests/`만 CPU 모드로 실행합니다.
 ## v1.56
 - `training.simple`: `zero_grad(set_to_none=True)` 호출을 예외 처리 래핑하고, 패딩만 있는 배치·더미 옵티마이저를 안전하게 처리하도록 보강했습니다.
 - `service.infer`: 트랜스포머 모델에만 토크나이저를 필수로 요구하도록 검증 조건을 보강했습니다.

--- a/src/training/simple.py
+++ b/src/training/simple.py
@@ -23,8 +23,9 @@ try:
     torch.set_float32_matmul_precision("high")
 except AttributeError:
     pass # Older torch versions may not have this
-sdp_kernel(enable_flash=True, enable_mem_efficient=True, enable_math=False)
-torch.backends.cudnn.benchmark = True
+if os.getenv("DISABLE_SDP_KERNEL") != "1":
+    sdp_kernel(enable_flash=True, enable_mem_efficient=True, enable_math=False)
+torch.backends.cudnn.benchmark = os.getenv("DISABLE_CUDNN_BENCHMARK") != "1"
 
 
 from torch import nn, optim


### PR DESCRIPTION
## Summary
- add environment variable guards for PyTorch `sdp_kernel` and `cudnn.benchmark`
- document CPU-only testing policy and new guards in Changelog
- update dataset description terminology in AGENTS

## Testing
- `python -m compileall src`
- `ALLOW_CPU_TRAINING=1 pytest -q`
- `ALLOW_CPU_TRAINING=1 python dry-run`

------
https://chatgpt.com/codex/tasks/task_e_689a04113cd8832ab4676c24f39e851f