### PR TITLE
chore: log gpu and env status

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # 변경 이력
+## v1.58: simple.py에 GPU/ENV 상태 로그(2줄) 추가 — 기능/성능 변경 없음.
 ## v1.57
 - `training.simple`에 sdp_kernel·cudnn 환경 변수 가드를 추가했습니다. Codex 내부 테스트는 GPU 미지원으로 `ALLOW_CPU_TRAINING=1` 설정 후 `tests/`만 CPU 모드로 실행합니다.
 ## v1.56

--- a/src/training/simple.py
+++ b/src/training/simple.py
@@ -16,6 +16,7 @@ import platform
 from pathlib import Path
 import os
 import torch
+logger = logging.getLogger(__name__)
 
 # Performance settings from GPT instructions
 from torch.backends.cuda import sdp_kernel
@@ -26,6 +27,8 @@ except AttributeError:
 if os.getenv("DISABLE_SDP_KERNEL") != "1":
     sdp_kernel(enable_flash=True, enable_mem_efficient=True, enable_math=False)
 torch.backends.cudnn.benchmark = os.getenv("DISABLE_CUDNN_BENCHMARK") != "1"
+logger.info(f"[GPU] cuda_available={torch.cuda.is_available()} device={(torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'CPU')}")
+logger.info(f"[ENV] DISABLE_SDP_KERNEL={os.getenv('DISABLE_SDP_KERNEL')} DISABLE_CUDNN_BENCHMARK={os.getenv('DISABLE_CUDNN_BENCHMARK')} cudnn.benchmark={torch.backends.cudnn.benchmark}")
 
 
 from torch import nn, optim
@@ -37,8 +40,6 @@ from ..model.transformer import Seq2SeqTransformer, save_transformer, load_trans
 from ..utils.tokenizer import SentencePieceTokenizer
 from .helpers import PairDataset, collate, timed_collate, log_dataset_stats
 from .checkpoint import save_checkpoint, load_checkpoint
-
-logger = logging.getLogger(__name__)
 
 def _prepare_dataset(
     samples: List[InstructionSample], tokenizer: SentencePieceTokenizer, is_pretrain: bool


### PR DESCRIPTION
## Summary
- log GPU availability and key environment variables during training setup
- record GPU/ENV logging addition in changelog

## Testing
- `python -m compileall src`
- `rg "[GPU] cuda_available=" -n`
- `rg "[ENV] DISABLE_SDP_KERNEL=" -n`


------
https://chatgpt.com/codex/tasks/task_e_689b326e5a40832aa7bae3ed9ad58cbd