### PR TITLE
chore: warn on invalid env inputs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # 변경 이력
+## v1.59: ENV 오입력 경고 로그(2줄) 추가 — 기능/성능 변경 없음.
 ## v1.58: simple.py에 GPU/ENV 상태 로그(2줄) 추가 — 기능/성능 변경 없음.
 ## v1.57
 - `training.simple`에 sdp_kernel·cudnn 환경 변수 가드를 추가했습니다. Codex 내부 테스트는 GPU 미지원으로 `ALLOW_CPU_TRAINING=1` 설정 후 `tests/`만 CPU 모드로 실행합니다.

--- a/src/training/simple.py
+++ b/src/training/simple.py
@@ -29,6 +29,8 @@ if os.getenv("DISABLE_SDP_KERNEL") != "1":
 torch.backends.cudnn.benchmark = os.getenv("DISABLE_CUDNN_BENCHMARK") != "1"
 logger.info(f"[GPU] cuda_available={torch.cuda.is_available()} device={(torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'CPU')}")
 logger.info(f"[ENV] DISABLE_SDP_KERNEL={os.getenv('DISABLE_SDP_KERNEL')} DISABLE_CUDNN_BENCHMARK={os.getenv('DISABLE_CUDNN_BENCHMARK')} cudnn.benchmark={torch.backends.cudnn.benchmark}")
+if (v:=os.getenv('DISABLE_SDP_KERNEL')) not in (None, '0', '1'): logger.warning(f"[ENV] DISABLE_SDP_KERNEL='{v}' — only '1' disables; others are ignored.")
+if (v:=os.getenv('DISABLE_CUDNN_BENCHMARK')) not in (None, '0', '1'): logger.warning(f"[ENV] DISABLE_CUDNN_BENCHMARK='{v}' — only '1' disables; others are ignored.")
 
 
 from torch import nn, optim


### PR DESCRIPTION
## Summary
- warn when DISABLE_SDP_KERNEL or DISABLE_CUDNN_BENCHMARK has non-`1` values
- document env warning log addition in changelog

## Testing
- `python -m compileall src`
- `grep -RF "[ENV] DISABLE_SDP_KERNEL='{"`
- `grep -RF "[ENV] DISABLE_CUDNN_BENCHMARK='{"`


------
https://chatgpt.com/codex/tasks/task_e_689b362e5f48832a84f0461160fa44e9