### PR TITLE
feat: support INI config overrides

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # 변경 이력
+## v1.69: trainconfig.ini 기반 추론/학습 파라미터 오버라이드 추가.
+- service.py에 INI 로더와 `_resolve_params`를 도입해 [CFG] 로그와 함께 생성 파라미터를 적용.
+- start_training이 INI의 train 섹션 값을 config에 병합하여 UI 없이도 수치 조정 가능.
+- 루트에 `trainconfig.ini` 샘플 파일을 추가.
 ## v1.68: 레거시 체크포인트 vocab 추론 로드 및 DummyModel 로깅 가드 추가.
 - 구형 ckpt에 vocab 메타가 없을 때 가중치 행렬에서 단어 수를 추론하여 트랜스포머 로드.
 - DummyModel 로드 시 parameters() 부재로 발생하던 로깅 예외를 _param_count 가드로 방지.

--- a/trainconfig.ini
+++ b/trainconfig.ini
@@ -1,0 +1,23 @@
+[generate]
+temperature = 0.7
+top_p = 0.9
+max_new_tokens = 128
+repetition_penalty = 1.1
+seed = 42
+top_k = 0
+no_repeat_ngram_size = 0
+num_beams = 1
+do_sample = yes
+stop =
+
+[train]
+epochs = 3
+learning_rate = 0.0002
+warmup_steps = 0
+batch_size = 32
+gradient_accumulation_steps = 1
+max_seq_len = 512
+label_smoothing = 0.0
+weight_decay = 0.0
+grad_clip = 1.0
+min_lr = 0.0


### PR DESCRIPTION
## Summary
- load generation and training parameters from `trainconfig.ini` using `configparser`
- apply INI-based overrides in `ChatbotService` during training start and inference
- add sample `trainconfig.ini` and document new override mechanism

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1378b2b20832ab81dcbcb114723f4