### PR TITLE
fix: unify spm hash and enhance spm training error

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -223,9 +223,10 @@ class ChatbotService:
                 if ckpt.exists():
                     info = torch.load(ckpt, map_location="cpu").get("tokenizer_info", {})
                     ps = info.get("piece_size")
-                    sha = info.get("sha256")
-                    if ps is not None and sha:
-                        if ps != self.tokenizer.sp.GetPieceSize() or sha != _sha256(spm_path):
+                    ckpt_sha = info.get("sha256")
+                    if ps is not None and ckpt_sha:
+                        sha = hashlib.sha256(Path(spm_path).read_bytes()).hexdigest()
+                        if ps != self.tokenizer.sp.GetPieceSize() or ckpt_sha != sha:
                             msg = "spm mismatch: piece_size/sha256 differ"
                             logging.getLogger(__name__).error("[SERVE] %s", msg)
                             raise RuntimeError(msg)

--- a/src/training/simple.py
+++ b/src/training/simple.py
@@ -250,10 +250,10 @@ def train(
         spm_model_path = (Path.cwd() / spm_model_path).resolve()
     spm_model_path.parent.mkdir(parents=True, exist_ok=True)
     if not spm_model_path.exists():
-        subprocess.run(
-            [sys.executable, str(Path.cwd() / "train_spm.py")],
-            check=True,
-        )
+        try:
+            subprocess.run([sys.executable, str(Path.cwd() / "train_spm.py")], check=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"SPM 생성 실패: {e}") from e
     if not spm_model_path.exists():
         raise FileNotFoundError(f"SentencePiece model not found: {spm_model_path}")
     tokenizer = SentencePieceTokenizer(str(spm_model_path))


### PR DESCRIPTION
## Summary
- unify SPM file hash check with hashlib and error log
- add clearer error for SentencePiece generator failures

## Testing
- `python -m compileall .`
- `ALLOW_CPU_TRAINING=1 python - <<'PY'
import logging
logging.basicConfig(level=logging.INFO)
from src.service.service import ChatbotService
svc=ChatbotService()
res=svc.start_training('finetune')
print(res)
PY`
- `ALLOW_CPU_TRAINING=1 python - <<'PY'
import logging
logging.basicConfig(level=logging.INFO)
from src.service.service import ChatbotService
svc=ChatbotService()
res=svc.start_training('finetune')
print(res)
PY`
- `python - <<'PY'
import logging
logging.basicConfig(level=logging.INFO)
from src.service.service import ChatbotService
try:
    svc=ChatbotService()
except Exception as e:
    print('RAISED:', type(e).__name__, e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68abdd84417c832a9a947bfb6f7c1234