### PR TITLE
docs: 저장소 점검 보고서 추가

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # 변경 이력
 ## vNEXT (2025-08-26, KST)
+- 저장소 핵심 로직 점검 결과를 `report/issues.txt`로 정리하고 주요 결함 12건과 개선 방안을 문서화했습니다.
+  - Training Config diff: N/A
+  - Logs: report/issues.txt (정적 분석)
+  - Runtime: 코드 리뷰
 - SDP/cuDNN 환경 가드 및 로그 보강.
   - Training Config diff: N/A
   - Logs: [CFG-TRAIN] sdp=flash=True,mem=True,math=False, cudnn.benchmark=True / [CFG-GEN] t=0.30 tp=0.90 k=0 mnt=128 rep=1.10 beams=1 sample=yes

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,29 @@
 읽음 확인
 # WORKLOG
+Date(KST): 2025-09-16
+Agent: Codex
+Repo: /workspace/cb_t03
+Branch: work
+HEAD: c1b7c6bb14df
+Dirty: no
+Status: DONE (2025-09-16)
+
+Directives:
+  - 지시-1) 저장소 전체 점검 결과를 report/issues.txt로 정리하여 사용자에게 제공.
+  - 지시-2) 핵심 로직 이상 징후를 식별하고 개선 방향을 기술.
+  - 지시-3) 작업 내역을 WORKLOG·Changelog에 문서화하고 저장소 규칙을 준수.
+
+Actions:
+  - 처리-1) report/issues.txt 작성 — 핵심 로직, 토크나이저, 학습 루프, 서비스 로직 문제를 10건 이상 정리.
+  - 처리-2) WORKLOG/Changelog를 갱신하여 점검 범위와 산출물을 기록.
+
+FilesChanged:
+  - report/issues.txt (신규)
+  - WORKLOG.md
+  - Changelog.md
+
+---
+# WORKLOG
 Date(KST): 2025-08-26
 Agent: Codex
 Repo: /workspace/cb_t03

--- a/report/issues.txt
+++ b/report/issues.txt
@@ -1,0 +1,54 @@
+# LLM 점검 보고서
+
+## 1. SentencePieceTokenizer ID 시프트로 `<unk>` 토큰 미사용
+- `encode()`가 SentencePiece ID에 `self.num_special_tokens`를 다시 더해 실제 ID가 4부터 시작하며 `<unk>`(ID 3)이 영구히 사용되지 않습니다.
+- `<unk>` 슬롯이 비어 있어 임베딩 자원이 낭비되고, 외부에서 로드한 vocab과도 어긋납니다.
+- **개선**: ID 시프트를 제거하고 SentencePiece 특수 토큰 정의와 동일한 인덱스를 유지한 뒤, 관련 PAD/BOS/EOS 상수를 전역적으로 정합시키십시오.
+
+## 2. SPM 학습 스크립트 간 특수 토큰 ID 불일치
+- 서비스 내 `_autotrain_spm()`은 pad/bos/eos/unk를 0~3으로 예약하지만, `train_spm.py`는 `<unk>`만 0으로 유지하고 나머지는 비활성화합니다.
+- 서로 다른 vocab 규약이 생성되어 학습·추론 파이프라인이 호환되지 않습니다.
+- **개선**: 두 스크립트가 동일한 `pad_id/bos_id/eos_id/unk_id`와 추가 옵션을 공유하도록 파라미터를 통일하고, 토크나이저 적합성 검사를 추가하십시오.
+
+## 3. CosineAnnealingLR가 배치마다 스텝을 진행해 학습률 스케줄이 붕괴
+- 스케줄러가 `T_max=epochs`로 생성되지만 `_train_epoch()`가 매 미니배치마다 `scheduler.step()`을 호출해 한 에폭이 끝나기도 전에 학습률이 최솟값으로 떨어집니다.
+- **개선**: `T_max`를 총 스텝 수(에폭×배치 수)로 바꾸거나, 스케줄러 스텝을 에폭 종료 시점 한 번으로 이동하여 의도한 코사인 곡선을 유지해야 합니다.
+
+## 4. 디코더 cross-attention 마스크가 4차원으로 확장되어 메모리를 과소비
+- `Seq2SeqTransformer.forward()`가 `src_pad`를 `B×H×T×S` 형태로 확장한 `mem_mask`로 변환하여 각 디코더 레이어에 전달합니다.
+- 이 방식은 헤드 수와 타깃 길이에 비례한 대규모 불리언 텐서를 매번 생성해 GPU 메모리를 낭비합니다.
+- **개선**: `DecoderLayer`에 `mem_key_padding_mask` 인자를 추가하고 `MultiHeadAttention`의 `key_padding_mask`를 활용해 2차원 패딩 마스크만 사용하십시오.
+
+## 5. Seq2SeqTransformer 추론이 샘플링 파라미터를 무시
+- 서비스에서 `temperature/top_p/top_k` 등을 수집하지만, `Seq2SeqTransformer.generate()` 호출에는 `max_new_tokens`만 전달되어 확률적 샘플링 제어가 불가능합니다.
+- **개선**: 커스텀 모델의 `generate()`가 온도·탑-k/p·빔 탐색 등 파라미터를 지원하도록 확장하고, 서비스 계층에서 해당 값을 연결하십시오.
+
+## 6. ChatbotService 초기화 시 파인튜닝 데이터 전체를 즉시 메모리에 적재
+- 생성자에서 `load_instruction_dataset(self.finetune_dir)`를 바로 호출하여 서버 기동 시 대용량 데이터를 한 번에 읽어옵니다.
+- 긴 시작 지연과 불필요한 메모리 사용을 유발합니다.
+- **개선**: `self.dataset`을 지연 로드하도록 초기화하고, 학습 진입 시점에만 필요한 데이터셋을 로드하십시오.
+
+## 7. SPM 자동 학습 경로가 기본값 미설정 시 `Path("None")`으로 고정
+- 자동 학습이 필요한 경우 `cfg.get("pretrain_dir"/"finetune_dir")` 값을 그대로 `Path(str(...))`로 변환하여, 설정이 비어 있으면 문자열 `"None"` 경로를 탐색합니다.
+- 실제 데이터 없이 SPM 트레이너가 실패합니다.
+- **개선**: 기본값으로 `self.pretrain_dir/self.finetune_dir`을 사용하고, 경로 존재 여부를 사전 검증한 후 명확한 오류를 보고하십시오.
+
+## 8. 모델 삭제(delete_model)가 STOP 센티넬만 생성하고 실제 파일은 남김
+- 삭제 요청 시 `models/STOP` 파일만 만들고 `.pth`·`.ckpt` 파일은 삭제하지 않아 디스크 공간과 UI 기대 동작이 불일치합니다.
+- **개선**: 센티넬 생성 전에 대상 모델·체크포인트 파일을 삭제하고, 실패 시 경고/예외를 남기도록 수정하십시오.
+
+## 9. 체크포인트 로더가 항상 GPU 맵핑을 강제
+- `torch.load(..., map_location='cuda')`로 고정되어 GPU가 없는 환경 또는 CPU 재개 시 즉시 예외가 발생합니다.
+- **개선**: `torch.cuda.is_available()` 여부에 따라 `'cuda'/'cpu'`를 분기하거나, 사용자 지정 map_location 인자를 허용하십시오.
+
+## 10. AutoTuner가 혼합정밀 옵션을 항상 False로 고정
+- VRAM이 충분해도 `use_mixed_precision`을 False로 반환하여 AGENTS 지침의 GPU 학습 기본 정책과 충돌합니다.
+- **개선**: GPU/VRAM 용량을 평가해 적절할 때 True를 기본값으로 반환하도록 로직을 보강하고, 관련 테스트를 업데이트하십시오.
+
+## 11. 설정 파일 입출력에서 컨텍스트 매니저를 사용하지 않아 파일 핸들 누수 위험
+- `load_config()`와 `save_config()`가 `open()`을 직접 호출하여 예외 발생 시 파일 핸들이 닫히지 않을 수 있습니다.
+- **개선**: `with open(...)` 컨텍스트 매니저를 사용해 파일을 안전하게 열고 닫으십시오.
+
+## 12. SentencePieceTokenizer가 vocab 매핑을 제공하지 않아 모델 저장 헬퍼와 호환되지 않음
+- `save_transformer()`는 `vocab: Dict[str, int]`를 요구하지만, `SentencePieceTokenizer`에는 `stoi/itos` 속성이 없어 직접 전달할 방법이 없습니다.
+- **개선**: 토크나이저에 `{piece: id}`/`{id: piece}` 매핑 프로퍼티를 추가하거나, 저장 유틸이 SentencePieceProcessor에서 vocab을 직렬화하도록 확장하십시오.


### PR DESCRIPTION
## Summary
- report/issues.txt에 핵심 로직 결함 12건과 개선 방안을 정리한 점검 보고서를 추가했습니다.
- WORKLOG와 Changelog vNEXT를 업데이트하여 점검 범위와 산출물을 기록했습니다.

## Testing
- Not run (문서/리포트 작성 작업)


------
https://chatgpt.com/codex/tasks/task_e_68c88d62f05c832aa790367244b17c3c