### PR TITLE
config 입출력 컨텍스트 매니저 적용 및 테스트 추가

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,11 @@
 # 변경 이력
+## v1.82: config 입출력 컨텍스트 매니저 및 테스트 보강 (2025-09-17, KST)
+- Config: `load_config`/`save_config`에서 `with open(...)` 컨텍스트 매니저를 사용해 예외 상황에서도 파일 핸들을 안전하게 정리하도록 수정했습니다.
+  - Reference: report/issues.txt 항목 11 대응
+- Test: `tests/test_config_io.py`를 신설해 CONFIG_PATH 재설정, 손상된 JSON 복구, 저장 결과 지속성을 검증했습니다.
+  - Test: `pytest -q` (17 passed, 3 skipped)
+  - Runtime: CPU pytest
+
 ## v1.81: 로그 버전 표기 정정 (2025-09-17, KST)
 - WORKLOG 상단 항목의 HEAD 해시가 병합 커밋(`4565faa74584ff44ac1561ae5823f48ee6ae1258`)과 불일치하던 문제를 수정했습니다.
 - 문서 릴리스 기록이 `vNEXT`로 남아 있던 항목을 `v1.80`으로 확정하고 날짜를 2025-09-16(KST)로 조정했습니다.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -4,6 +4,38 @@ Date(KST): 2025-09-17
 Agent: Codex
 Repo: /workspace/cb_t03
 Branch: work
+HEAD: 74347aa5025ffb5d9e1565ef59eb4635c3bcd138
+Dirty: no
+Status: DONE (2025-09-17)
+
+Directives:
+  - 지시-1) report/issues.txt 항목 11을 반영하여 config 입출력에서 컨텍스트 매니저를 사용하도록 수정.
+  - 지시-2) 변경 회귀를 방지할 테스트 케이스를 작성하고 결과를 문서화.
+
+Actions:
+  - 처리-1) src/config.load_config/save_config에 with open(...) 컨텍스트 매니저를 적용해 예외 발생 시 파일 핸들 누수를 방지.
+  - 처리-2) tests/test_config_io.py를 추가해 CONFIG_PATH 재설정, 손상된 JSON 복구, 저장 결과를 검증하는 단위 테스트를 구축.
+
+FilesChanged:
+  - src/config.py
+  - tests/test_config_io.py
+
+Logs:
+  - pytest -q
+
+Test:
+  - cmd: pytest -q
+  - metrics: 17 passed, 3 skipped
+  - warn/fail(raw): none
+
+Pending/Rollback/Next: none
+
+---
+# WORKLOG
+Date(KST): 2025-09-17
+Agent: Codex
+Repo: /workspace/cb_t03
+Branch: work
 HEAD: 4565faa74584
 Dirty: no
 Status: DONE (2025-09-17)

--- a/src/config.py
+++ b/src/config.py
@@ -54,7 +54,8 @@ DEFAULT_CONFIG: Dict[str, Any] = {
 def load_config() -> Dict[str, Any]:
     if CONFIG_PATH.exists():
         try:
-            data = json.load(open(CONFIG_PATH, encoding="utf-8"))
+            with CONFIG_PATH.open(encoding="utf-8") as file:
+                data = json.load(file)
         except Exception:
             data = {}
     else:
@@ -66,4 +67,5 @@ def load_config() -> Dict[str, Any]:
 
 def save_config(cfg: Dict[str, Any]) -> None:
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    json.dump(cfg, open(CONFIG_PATH, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
+    with CONFIG_PATH.open("w", encoding="utf-8") as file:
+        json.dump(cfg, file, ensure_ascii=False, indent=2)

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,0 +1,64 @@
+"""Configuration IO helper tests."""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator
+
+import pytest
+
+from src import config as base_config
+
+
+@pytest.fixture()
+def temporary_config_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[ModuleType]:
+    """Reload src.config with a temporary CONFIG_PATH and restore it after use."""
+    original_env = os.environ.get("CONFIG_PATH")
+    temporary_path = tmp_path / "nested" / "current.json"
+    monkeypatch.setenv("CONFIG_PATH", str(temporary_path))
+    module = importlib.reload(base_config)
+    try:
+        yield module
+    finally:
+        if original_env is None:
+            monkeypatch.delenv("CONFIG_PATH", raising=False)
+        else:
+            monkeypatch.setenv("CONFIG_PATH", original_env)
+        importlib.reload(base_config)
+
+
+def test_load_config_returns_defaults_when_missing(
+    temporary_config_module: ModuleType,
+) -> None:
+    """load_config should return DEFAULT_CONFIG when the file does not exist."""
+    assert temporary_config_module.load_config() == temporary_config_module.DEFAULT_CONFIG
+
+
+def test_load_config_handles_invalid_json(temporary_config_module: ModuleType) -> None:
+    """load_config should ignore invalid JSON and fall back to defaults."""
+    invalid_file = temporary_config_module.CONFIG_PATH
+    invalid_file.parent.mkdir(parents=True, exist_ok=True)
+    invalid_file.write_text("{ invalid", encoding="utf-8")
+
+    loaded = temporary_config_module.load_config()
+
+    assert loaded == temporary_config_module.DEFAULT_CONFIG
+
+
+def test_save_config_persists_payload(temporary_config_module: ModuleType) -> None:
+    """save_config should create parent directories and persist JSON content."""
+    config_payload = temporary_config_module.DEFAULT_CONFIG.copy()
+    config_payload["num_epochs"] = 5
+
+    temporary_config_module.save_config(config_payload)
+
+    with temporary_config_module.CONFIG_PATH.open(encoding="utf-8") as file:
+        stored = json.load(file)
+
+    assert stored["num_epochs"] == 5
+    assert temporary_config_module.CONFIG_PATH.exists()


### PR DESCRIPTION
## Summary
- load_config/save_config에 with open(...) 컨텍스트 매니저를 적용해 예외 발생 시 파일 핸들을 안전하게 정리했습니다.
- CONFIG_PATH 재설정, 손상된 JSON 복구, 저장 결과 지속성을 검증하는 tests/test_config_io.py를 추가했습니다.

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9f4431a90832a883a9c8b48481979