### PR TITLE
Refactor config storage to trainconfig.ini

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,10 @@
 # 변경 이력
+## v1.83: trainconfig.ini 기반 설정 일원화 (2025-09-17, KST)
+- Config: `load_config`/`save_config`가 `trainconfig.ini`를 직접 읽고 쓰도록 수정하여 구버전 JSON(`configs/current.json`) 경로 의존성을 제거했습니다.
+- Config: INI 섹션 덮어쓰기 로직을 보강해 `[train]` 공통 값과 모드별 `[pretrain]`/`[finetune]` 키를 일관되게 업데이트합니다.
+- Test: `tests/test_config_io.py`를 INI 흐름에 맞춰 재작성하고 trainconfig 갱신 동작을 검증했습니다.
+- Doc: README 재개 절차에서 `trainconfig.ini` 기준 안내로 교체했습니다.
+
 ## v1.82: config 입출력 컨텍스트 매니저 및 테스트 보강 (2025-09-17, KST)
 - Config: `load_config`/`save_config`에서 `with open(...)` 컨텍스트 매니저를 사용해 예외 상황에서도 파일 핸들을 안전하게 정리하도록 수정했습니다.
   - Reference: report/issues.txt 항목 11 대응

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ python train_spm.py --input "datas/pretrain/**/*.txt"
 - 장애 시: 콘솔 로그 마지막 200줄과 스택트레이스 원문만 수집·보고.
 
 ### 재개(resume) 절차
-- 학습 중단 후 재개하려면 `configs/current.json`에 `{"resume": true}`를 유지하고, 최근 체크포인트가 `models/`에 존재해야 합니다.
+- 학습 중단 후 재개하려면 `trainconfig.ini`의 대상 섹션(`[pretrain]` 또는 `[finetune]`)에서 `resume = yes`로 지정하고, 최근 체크포인트가 `models/`에 존재해야 합니다.
 - `python run.py` 실행 후 UI에서 재개 모드를 선택하면 됩니다.
 - 로그에 `[TRAIN-START]` / `[CFG]` / `[TRAIN-END]`가 순서대로 출력되면 정상 재개입니다.
 - 실패 시 콘솔 로그 마지막 200줄과 스택트레이스 원문을 보고하십시오.
@@ -133,12 +133,12 @@ python train_spm.py --input "datas/pretrain/**/*.txt"
 - `python run.py` 실행 → UI에서 질문 1회 입력.
 - 로그에서 `[SERVE] model_loaded` / `[GEN] max_new_tokens=` 문구가 출력되는지 확인.
 - 응답이 반환되면 정상. 실패 시 콘솔 로그 마지막 200줄과 스택트레이스 원문을 수집·보고.
-- (선택) `configs/current.json`의 `resume`과 무관하게 서빙은 최신 체크포인트를 자동 로드합니다.
+- (선택) `trainconfig.ini`의 `resume` 설정과 관계없이 서빙은 최신 체크포인트를 자동 로드합니다.
 
 
 ### MVP 릴리스 체크리스트
 - 학습 스모크(50~100 step): 로그에 `[GPU]`/`[ENV]`/`[CFG]`/`[DATA]`/`[TRAIN-START]`→`[TRAIN-END]` 순서로 출력됨.
-- 재개(20 step): `configs/current.json`의 `{"resume": true}` 유지, 체크포인트 존재 확인 후 재개 성공.
+- 재개(20 step): `trainconfig.ini`에서 `resume = yes` 유지, 체크포인트 존재 확인 후 재개 성공.
 - 서빙 1회: `[SERVE] model_loaded`와 `[GEN] max_new_tokens=` 로그가 출력되고 응답이 반환됨.
 - 실패 시 보고: 콘솔 로그 **마지막 200줄** + **스택트레이스 원문** + GPU/torch 버전.
 - ENV 규칙: `DISABLE_*` 값은 '1'만 비활성(기타 값은 무시, 경고 로그 발생).

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -4,6 +4,41 @@ Date(KST): 2025-09-17
 Agent: Codex
 Repo: /workspace/cb_t03
 Branch: work
+HEAD: ca9acae66ffb7db585945ecd029ca53b4f48ffbb
+Dirty: no
+Status: DONE (2025-09-17)
+
+Directives:
+  - 지시-1) `configs/current.json` 경로 의존성을 제거하고 trainconfig.ini 기반으로 설정을 통합.
+  - 지시-2) 코드·테스트·문서를 동기화하고 결과를 보고.
+
+Actions:
+  - 처리-1) src/config.py를 INI 파서/쓰기 로직으로 전환하고 JSON 로딩/저장을 제거.
+  - 처리-2) tests/test_config_io.py를 INI 흐름 검증으로 재작성.
+  - 처리-3) README 재개 절차와 Changelog 항목을 trainconfig 기준으로 갱신.
+
+FilesChanged:
+  - src/config.py
+  - tests/test_config_io.py
+  - README.md
+  - Changelog.md
+
+Logs:
+  - pytest -q
+
+Test:
+  - cmd: pytest -q
+  - metrics: 20 passed, 3 skipped
+  - warn/fail(raw): none
+
+Pending/Rollback/Next: none
+
+---
+# WORKLOG
+Date(KST): 2025-09-17
+Agent: Codex
+Repo: /workspace/cb_t03
+Branch: work
 HEAD: 74347aa5025ffb5d9e1565ef59eb4635c3bcd138
 Dirty: no
 Status: DONE (2025-09-17)

--- a/src/config.py
+++ b/src/config.py
@@ -1,17 +1,18 @@
-"""Project configuration helpers."""
+"""프로젝트 설정 도우미."""
 from __future__ import annotations
 
-import json
+import configparser
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict
 
-CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", "configs/current.json"))
+CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", "trainconfig.ini"))
 
 DEFAULT_CONFIG: Dict[str, Any] = {
     "num_epochs": 20,
     "batch_size": 48,
-    "learning_rate": 2e-4,  # 값 표기는 소수(예: 0.0002). 코드 기본값(2e-4)와 동등.
+    "learning_rate": 2e-4,
     "dropout_ratio": 0.1,
     "grad_clip": 1.0,
     "min_lr": 1e-5,
@@ -50,22 +51,157 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "resume": False,
 }
 
+_BOOL_TRUE = {"1", "true", "yes", "y", "on"}
+_TRAIN_SECTION_KEYS = (
+    "grad_clip",
+    "min_lr",
+    "use_mixed_precision",
+    "model_dim",
+    "ff_dim",
+    "num_heads",
+    "num_encoder_layers",
+    "num_decoder_layers",
+    "num_workers",
+    "pin_memory",
+    "spm_model_path",
+)
+_MODE_KEY_MAP = {
+    "num_epochs": "epochs",
+    "batch_size": "batch_size",
+    "learning_rate": "learning_rate",
+    "dropout_ratio": "dropout_ratio",
+    "resume": "resume",
+}
+
+
+def _cast_value(raw: str, default: Any) -> Any:
+    """INI 문자열을 기본값 타입에 맞춰 변환."""
+    if isinstance(default, bool):
+        return raw.strip().lower() in _BOOL_TRUE
+    if isinstance(default, int):
+        try:
+            return int(float(raw))
+        except (TypeError, ValueError):
+            return default
+    if isinstance(default, float):
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return default
+    return raw.strip()
+
+
+def _format_value(value: Any) -> str:
+    """INI에 기록할 문자열 표현을 반환."""
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, float):
+        text = f"{value:.10f}".rstrip('0').rstrip('.')
+        return text or '0'
+    return str(value)
+
+
+def _ensure_section(text: str, section: str) -> str:
+    """섹션이 없으면 새로 추가."""
+    pattern = re.compile(rf"^\[{re.escape(section)}\]", re.MULTILINE)
+    if pattern.search(text):
+        return text
+    suffix = "\n" if text and not text.endswith("\n") else ""
+    return f"{text}{suffix}[{section}]\n"
+
+
+def _replace_in_section(text: str, section: str, key: str, value: str) -> str:
+    """특정 섹션에서 키 값을 교체하거나 새로 추가."""
+    section_pattern = re.compile(
+        rf"(^\[{re.escape(section)}\][^\n]*\n)(?P<body>.*?)(?=^\[|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = section_pattern.search(text)
+    if not match:
+        text = _ensure_section(text, section)
+        match = section_pattern.search(text)
+        if not match:
+            # 섹션 생성 후에도 발견되지 않으면 끝에 값 추가
+            suffix = "\n" if text and not text.endswith("\n") else ""
+            return f"{text}{suffix}{key} = {value}\n"
+
+    body = match.group("body")
+    key_pattern = re.compile(
+        rf"(?m)^(?P<indent>\s*{re.escape(key)}\s*=\s*)(?P<val>[^\n#;]*?)(?P<trail>\s*)(?P<comment>[#;].*)?$"
+    )
+
+    def repl(m: re.Match[str]) -> str:
+        indent = m.group("indent")
+        trail = m.group("trail")
+        comment = m.group("comment") or ""
+        return f"{indent}{value}{trail}{comment}"
+
+    new_body, count = key_pattern.subn(repl, body, count=1)
+    if count == 0:
+        insertion = f"{key} = {value}\n"
+        if not body:
+            new_body = insertion
+        else:
+            base = body if body.endswith("\n") else f"{body}\n"
+            new_body = f"{base}{insertion}"
+
+    start, end = match.start("body"), match.end("body")
+    return f"{text[:start]}{new_body}{text[end:]}"
+
 
 def load_config() -> Dict[str, Any]:
-    if CONFIG_PATH.exists():
-        try:
-            with CONFIG_PATH.open(encoding="utf-8") as file:
-                data = json.load(file)
-        except Exception:
-            data = {}
-    else:
-        data = {}
+    """trainconfig.ini를 읽어 기본 설정과 병합."""
     cfg = DEFAULT_CONFIG.copy()
-    cfg.update({k: data.get(k, v) for k, v in DEFAULT_CONFIG.items()})
+    parser = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
+    try:
+        read_files = parser.read(CONFIG_PATH, encoding="utf-8")
+    except (OSError, configparser.Error):
+        read_files = []
+    if not read_files:
+        return cfg
+
+    if parser.has_section("train"):
+        for key in _TRAIN_SECTION_KEYS:
+            if parser.has_option("train", key):
+                raw = parser.get("train", key, fallback="")
+                cfg[key] = _cast_value(raw, DEFAULT_CONFIG.get(key))
+
+    loaded_from_pretrain: set[str] = set()
+    if parser.has_section("pretrain"):
+        for key, ini_key in _MODE_KEY_MAP.items():
+            if parser.has_option("pretrain", ini_key):
+                raw = parser.get("pretrain", ini_key, fallback="")
+                cfg[key] = _cast_value(raw, DEFAULT_CONFIG.get(key))
+                loaded_from_pretrain.add(key)
+
+    if parser.has_section("finetune"):
+        for key, ini_key in _MODE_KEY_MAP.items():
+            if key in loaded_from_pretrain:
+                continue
+            if parser.has_option("finetune", ini_key):
+                raw = parser.get("finetune", ini_key, fallback="")
+                cfg[key] = _cast_value(raw, DEFAULT_CONFIG.get(key))
+
     return cfg
 
 
 def save_config(cfg: Dict[str, Any]) -> None:
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with CONFIG_PATH.open("w", encoding="utf-8") as file:
-        json.dump(cfg, file, ensure_ascii=False, indent=2)
+    """trainconfig.ini 파일에 설정을 반영."""
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError(f"trainconfig.ini not found: {CONFIG_PATH}")
+
+    text = CONFIG_PATH.read_text(encoding="utf-8")
+    for key in _TRAIN_SECTION_KEYS:
+        if key in cfg and cfg[key] is not None:
+            value = _format_value(cfg[key])
+            text = _replace_in_section(text, "train", key, value)
+
+    for key, ini_key in _MODE_KEY_MAP.items():
+        if key in cfg and cfg[key] is not None:
+            value = _format_value(cfg[key])
+            text = _replace_in_section(text, "pretrain", ini_key, value)
+            text = _replace_in_section(text, "finetune", ini_key, value)
+
+    if not text.endswith("\n"):
+        text = f"{text}\n"
+    CONFIG_PATH.write_text(text, encoding="utf-8")

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,9 +1,8 @@
-"""Configuration IO helper tests."""
+"""설정 입출력 테스트."""
 from __future__ import annotations
 
 import importlib
-import json
-import os
+import re
 from pathlib import Path
 from types import ModuleType
 from typing import Iterator
@@ -12,53 +11,118 @@ import pytest
 
 from src import config as base_config
 
+SAMPLE_INI = """; 테스트용 기본 설정
+[train]
+grad_clip = 1.0             # 기울기 제한
+min_lr = 0.00001
+use_mixed_precision = yes
+model_dim = 256
+ff_dim = 1024
+num_heads = 8
+num_encoder_layers = 6
+num_decoder_layers = 6
+num_workers = 6
+pin_memory = yes
+spm_model_path = models/spm.model
+
+[pretrain]
+epochs = 20
+batch_size = 48
+learning_rate = 0.0002
+dropout_ratio = 0.1
+resume = no
+
+[finetune]
+epochs = 20
+batch_size = 48
+learning_rate = 0.0002
+dropout_ratio = 0.1
+resume = no
+"""
+
 
 @pytest.fixture()
 def temporary_config_module(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[ModuleType]:
-    """Reload src.config with a temporary CONFIG_PATH and restore it after use."""
-    original_env = os.environ.get("CONFIG_PATH")
-    temporary_path = tmp_path / "nested" / "current.json"
+    """CONFIG_PATH를 임시 경로로 지정한 모듈을 생성."""
+    temporary_path = tmp_path / "trainconfig.ini"
     monkeypatch.setenv("CONFIG_PATH", str(temporary_path))
     module = importlib.reload(base_config)
     try:
         yield module
     finally:
-        if original_env is None:
-            monkeypatch.delenv("CONFIG_PATH", raising=False)
-        else:
-            monkeypatch.setenv("CONFIG_PATH", original_env)
+        monkeypatch.delenv("CONFIG_PATH", raising=False)
         importlib.reload(base_config)
 
 
 def test_load_config_returns_defaults_when_missing(
     temporary_config_module: ModuleType,
 ) -> None:
-    """load_config should return DEFAULT_CONFIG when the file does not exist."""
-    assert temporary_config_module.load_config() == temporary_config_module.DEFAULT_CONFIG
+    """INI 파일이 없으면 DEFAULT_CONFIG를 반환."""
+    assert (
+        temporary_config_module.load_config()
+        == temporary_config_module.DEFAULT_CONFIG
+    )
 
 
-def test_load_config_handles_invalid_json(temporary_config_module: ModuleType) -> None:
-    """load_config should ignore invalid JSON and fall back to defaults."""
-    invalid_file = temporary_config_module.CONFIG_PATH
-    invalid_file.parent.mkdir(parents=True, exist_ok=True)
-    invalid_file.write_text("{ invalid", encoding="utf-8")
+def test_load_config_merges_ini_values(
+    temporary_config_module: ModuleType,
+) -> None:
+    """trainconfig.ini 값을 읽어 기본 설정을 덮어쓴다."""
+    temporary_config_module.CONFIG_PATH.write_text(
+        SAMPLE_INI, encoding="utf-8"
+    )
 
     loaded = temporary_config_module.load_config()
 
-    assert loaded == temporary_config_module.DEFAULT_CONFIG
+    assert loaded["grad_clip"] == 1.0
+    assert loaded["min_lr"] == 1e-5
+    assert loaded["use_mixed_precision"] is True
+    assert loaded["num_epochs"] == 20
+    assert loaded["batch_size"] == 48
+    assert loaded["learning_rate"] == pytest.approx(0.0002)
+    assert loaded["dropout_ratio"] == pytest.approx(0.1)
 
 
-def test_save_config_persists_payload(temporary_config_module: ModuleType) -> None:
-    """save_config should create parent directories and persist JSON content."""
-    config_payload = temporary_config_module.DEFAULT_CONFIG.copy()
-    config_payload["num_epochs"] = 5
+def test_save_config_updates_ini_sections(
+    temporary_config_module: ModuleType,
+) -> None:
+    """save_config가 train/pretrain/finetune 섹션 값을 갱신."""
+    temporary_config_module.CONFIG_PATH.write_text(
+        SAMPLE_INI, encoding="utf-8"
+    )
 
-    temporary_config_module.save_config(config_payload)
+    payload = {
+        "grad_clip": 0.5,
+        "min_lr": 5e-5,
+        "use_mixed_precision": False,
+        "pin_memory": False,
+        "num_epochs": 8,
+        "batch_size": 32,
+        "learning_rate": 5e-4,
+        "dropout_ratio": 0.2,
+        "resume": True,
+    }
 
-    with temporary_config_module.CONFIG_PATH.open(encoding="utf-8") as file:
-        stored = json.load(file)
+    temporary_config_module.save_config(payload)
 
-    assert stored["num_epochs"] == 5
-    assert temporary_config_module.CONFIG_PATH.exists()
+    text = temporary_config_module.CONFIG_PATH.read_text(encoding="utf-8")
+
+    train_section = re.search(r"\[train\](?P<body>.*?)(?:\n\[|\Z)", text, re.S)
+    assert train_section is not None
+    body = train_section.group("body")
+    assert re.search(r"grad_clip\s*=\s*0.5", body)
+    assert "# 기울기 제한" in body
+    assert re.search(r"use_mixed_precision\s*=\s*no", body)
+    assert re.search(r"pin_memory\s*=\s*no", body)
+
+    pretrain_section = re.search(r"\[pretrain\](?P<body>.*?)(?:\n\[|\Z)", text, re.S)
+    finetune_section = re.search(r"\[finetune\](?P<body>.*?)(?:\n\[|\Z)", text, re.S)
+    assert pretrain_section is not None and finetune_section is not None
+    for section in (pretrain_section.group("body"), finetune_section.group("body")):
+        assert re.search(r"epochs\s*=\s*8", section)
+        assert re.search(r"batch_size\s*=\s*32", section)
+        assert re.search(r"learning_rate\s*=\s*0.0005", section)
+        assert re.search(r"dropout_ratio\s*=\s*0.2", section)
+        assert re.search(r"resume\s*=\s*yes", section)


### PR DESCRIPTION
## Summary
- replace the JSON-based configuration loader/saver with trainconfig.ini parsing and section-aware writers
- rewrite the configuration IO tests to exercise the INI flow and ensure section updates are persisted
- align README resume instructions and changelog/worklog records with the new trainconfig-based workflow

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb20f04b2c832ab673520274f9d8c1